### PR TITLE
Implement enhanced Description field

### DIFF
--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -107,7 +107,7 @@
 			      "scaleZ": 1.42055011
 			    },
 			    "Nickname": "{{ slotLabel|raw|replace({"'":""}) }}",
-			    "Description": "{% if slot.dice == 2 and slot.card.deckLimit == 1 %}elite{% endif %}",
+			    "Description": "{% if slot.dice == 2 and slot.card.deckLimit == 1 %}elite {% endif %}{{slot.card.set_code}} {{slot.card.position}}",
 			    "ColorDiffuse": {
 			      "r": 0.713235259,
 			      "g": 0.713235259,
@@ -280,7 +280,7 @@
 			            "scaleZ": 1.42055011
 			          },
 			          "Nickname": "{{ slotLabel|raw|replace({"'":""}) }}",
-			          "Description": "",
+			          "Description": "{{slot.card.set_code}} {{slot.card.position}}",
 			          "ColorDiffuse": {
 			            "r": 0.713235259,
 			            "g": 0.713235259,


### PR DESCRIPTION
Added the set code and card number to the Description of each card.  This allows TTS scripts to reliably tell the difference between cards like old and new R2-D2.  With the new Description format, these cards would have descriptions of "SoR 42" and "LEG 35" respectively.  Elite characters would use the format "elite AW 10", for example.