### PR TITLE
Fix plot rotation

### DIFF
--- a/src/AppBundle/Resources/views/Export/tts.json.twig
+++ b/src/AppBundle/Resources/views/Export/tts.json.twig
@@ -98,7 +98,7 @@
 						"posY": {{ random(999) /1000 }},
 						"posZ": {{ random(999) /1000 }},
 						"rotX": {{ random(999) /1000 }},
-						"rotY": 270,
+						"rotY": {{ random(999) /1000 }},
 						"rotZ": {{ random(999) /1000 }},
 						"scaleX": 1.42055011,
 						"scaleY": 1,
@@ -118,7 +118,7 @@
 					"Sticky": true,
 					"Tooltip": true,
 					"CardID": {{ plot.card.ttscardid }},
-					"SidewaysCard": true,
+					"SidewaysCard": false,
 					"CustomDeck": {
 						{# All Plots use CustomDeck 473 #}
 						"473": {


### PR DESCRIPTION
Plot cards were exported sideways and the hold-alt-to-zoom was likewise messed up.  This fixes both issues.